### PR TITLE
Modify experiment scripts to use parallel task queue

### DIFF
--- a/experiments/query_kim_cnn_model.js
+++ b/experiments/query_kim_cnn_model.js
@@ -4,13 +4,14 @@ const request = require('request');
 const _ = require('lodash');
 const readline = require('readline');
 
-if (process.argv.length != 4) {
-    console.log('Usage: node query_kim_cnn_model.js API_URL num_items');
+if (process.argv.length != 5) {
+    console.log('Usage: node query_kim_cnn_model.js API_URL num_items concurrency');
     process.exit(1);
 }
 
 var url = process.argv[2];
 var num_items = process.argv[3];
+var concurrency = process.argv[4];
 
 function readFile(path, cb) {
     var data = [];
@@ -36,7 +37,7 @@ async.series([
     var t0 = process.hrtime();
     var latencies = [];
 
-    async.map(sts_dev, function(sent, callback) {
+    var parallel_tasks = sts_dev.map(sent => callback => {
         var request_start = process.hrtime();
         request.post(
             url,
@@ -57,19 +58,25 @@ async.series([
                 }
             }
         );
-    },
-    function(err, results) {
+    });
+
+    async.parallelLimit(parallel_tasks, concurrency, function(err, results) {
         console.log(results);
         var since_t0 = process.hrtime(t0);
         var elapsed = since_t0[0] + since_t0[1] / 1000000000;
         console.log('========================================');
+        var contains_timeout = _.find(results, result => {
+            var parsed_result = JSON.parse(result);
+            return _.has(parsed_result, 'message') && parsed_result['message'] === 'Endpoint request timed out';
+        });
         console.log(`${size} queries took ${elapsed} ms. Throughput is ${size / elapsed} qps.`);
+        console.log(`Contains timeouts: ${Boolean(contains_timeout)}`)
 
         latencies.sort();
         var p50 = latencies[Math.floor(latencies.length * 0.5) - 1];
         var p99 = latencies[Math.floor(latencies.length * 0.99) - 1];
         var avg = _.mean(latencies);
-        console.log(`${latencies.length} requests successfully returned. p50 latency is ${p50} s, p99 latency is ${p99}, avg. latency is ${avg}.`);
+        console.log(`${latencies.length} requests successfully returned. p50 latency is ${p50} s, p99 latency is ${p99} s, avg. latency is ${avg} s.`);
     });
 });
 

--- a/sm_cnn/sm_handler.py
+++ b/sm_cnn/sm_handler.py
@@ -20,7 +20,8 @@ def build_matrix(words, lookup):
             vec_raw = lookup[word]
             vec = np.array([float(f['N']) for f in vec_raw])
         else:
-            # random vector
+            # random vector if word not in lookup
+            print('Not found in Dynamo: ' + word)
             vec = np.random.rand(50)
 
         vec = vec.reshape(1, 1, vec.shape[0])


### PR DESCRIPTION
Originally all requests are sent at once. This is not good. This modification instead runs `concurrency` number of requests in parallel at max.